### PR TITLE
Only Print Title Once

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ This operation is automatic, but the generated META tags can be fully customized
 2. Activate the plugin through the plugins menu.
 3. Visit the configuration page ( Settings -> SEO Options) to set your SEO options.
  
+#### Release History
+2.0.1
+- fix for title being appended more than once. Props @cfleurynesn
+
+2.0.0
+- total rewrite
+
 
 #### Thanks
 The plugin was re-written by @theMikeD to bring the code in line with current best practices and standards.

--- a/add-seo-meta-tags.php
+++ b/add-seo-meta-tags.php
@@ -3,7 +3,7 @@
 /*
 Plugin Name: Add SEO Meta Tags
 Description: Adds the <em>Description</em> and <em>Keywords</em> XHTML META tags to your blog's <em>front page</em> and to each one of the <em>posts</em>, <em>static pages</em> and <em>category archives</em>. This operation is automatic, but the generated META tags can be fully customized. Please read the tips and all other info provided at the <a href="options-general.php?page=amt_options">configuration panel</a>.
-Version: 2.0.0
+Version: 2.0.1
 Author: George Notaras, Automattic, @theMikeD
 License: Apache License, Version 2.0
 

--- a/js/add-seo-meta-tags.js
+++ b/js/add-seo-meta-tags.js
@@ -97,7 +97,7 @@
 			}
 		 	if ( $title.val() === '' ) {
 		 		// If the title text entry area is blank, then we use the page title
-		 		$( "#mt_snippet .title" ).append( $( "p" ).text(  originalTitle ) );
+		 		$( "#mt_snippet .title" ).text(  originalTitle );
 		 		var count = originalTitle.length;
 		 	} else {
 		 		// Otherwise, use what we have after subbing in the page title for the %title% placeholder


### PR DESCRIPTION
This change prevents the script from printing all instances of the page title in the Description preview section.